### PR TITLE
add packeger for document

### DIFF
--- a/src/c20_client/document_download.py
+++ b/src/c20_client/document_download.py
@@ -37,8 +37,5 @@ def download_document(api_key, document_id):
     if data.status_code == 429:
         raise reggov_api_doc_error.ExceedCallLimitException
     document = data.json()
-    file_formats = extract_file_formats(document)
-    file_attachments = extract_attachments(document)
-    if file_formats:
-        return document, file_formats
-    return document, file_attachments
+
+    return document

--- a/src/c20_client/document_packager.py
+++ b/src/c20_client/document_packager.py
@@ -1,0 +1,25 @@
+from c20_client import json_jobs_helper
+
+
+def package_document(document, client_id, job_id):
+    folder_name = (document['agencyName']['value'] + "/" +
+                   document['docketId']['value'] + "/" +
+                   document['documentId']['value'] + "/")
+    data = {
+        'folder_name': folder_name,
+        'file_name': 'basic_document.json',
+        'data': document
+    }
+
+    jobs_list = []
+    if 'fileFormats' in document or 'attachments' in document:
+        jobs_list = json_jobs_helper.get_download_from_document(document)
+
+    return_document = {
+        'client_id': client_id,
+        'job_id': job_id,
+        'data': data,
+        'jobs': jobs_list
+    }
+
+    return return_document

--- a/src/c20_client/json_jobs_helper.py
+++ b/src/c20_client/json_jobs_helper.py
@@ -34,9 +34,20 @@ def get_download_from_document(document):
     """
     Get the download job from the data in the document endpoint
     """
+    file_formats = find_formats(document)
+
     jobs = {
         'job_type': 'download',
-        "fileFormats": document['fileFormats']
+        'fileFormats': file_formats
     }
-
     return jobs
+
+
+def find_formats(document):
+    if 'attachments' in document:
+        file_formats = []
+        for formats in document['attachments']:
+            file_formats += formats['fileFormats']
+    else:
+        file_formats = document['fileFormats']
+    return file_formats

--- a/tests/c20_client/test_document_packager.py
+++ b/tests/c20_client/test_document_packager.py
@@ -1,0 +1,165 @@
+import pytest
+from c20_client import document_packager
+
+CLIENT_ID = 1
+JOB_ID = 1
+
+TEST_JSON = {
+    'agencyName': {'value': 'test'},
+    'docketId': {'value': 'docket-number-5'},
+    'documentId': {'value': 'document-number-10'}
+}
+
+
+@pytest.fixture(name='document')
+def fixture_document():
+    response = document_packager.package_document(TEST_JSON,
+                                                  CLIENT_ID, JOB_ID)
+    return response
+
+
+ONE_FILE_FORMAT_JSON = {
+    'fileFormats': [
+        'URL'
+    ],
+    'agencyName': {'value': 'test'},
+    'docketId': {'value': 'docket-number-5'},
+    'documentId': {'value': 'document-number-10'}
+}
+
+
+@pytest.fixture(name='one_downloads_document')
+def fixture_one_downloads_document():
+    response = document_packager.package_document(ONE_FILE_FORMAT_JSON,
+                                                  CLIENT_ID, JOB_ID)
+    return response
+
+
+MANY_FILE_FORMAT_JSON = {
+    'fileFormats': [
+        'URL',
+        'URL2'
+    ],
+    'agencyName': {'value': 'test'},
+    'docketId': {'value': 'docket-number-5'},
+    'documentId': {'value': 'document-number-10'}
+}
+
+
+@pytest.fixture(name='many_downloads_document')
+def fixture_many_downloads_document():
+    response = document_packager.package_document(MANY_FILE_FORMAT_JSON,
+                                                  CLIENT_ID, JOB_ID)
+    return response
+
+
+ONE_ATTACHMENT_JSON = {
+    "attachments": [{
+        "attachmentOrderNumber": 1,
+        'fileFormats': [
+            'URL'
+        ]
+    }],
+    'agencyName': {'value': 'test'},
+    'docketId': {'value': 'docket-number-5'},
+    'documentId': {'value': 'document-number-10'}
+}
+
+
+@pytest.fixture(name='one_attachment_document')
+def fixture_one_attachment_document():
+    response = document_packager.package_document(ONE_ATTACHMENT_JSON,
+                                                  CLIENT_ID, JOB_ID)
+    return response
+
+
+ATTACHMENT_MANY_FILES_JSON = {
+    "attachments": [{
+        "attachmentOrderNumber": 1,
+        'fileFormats': [
+            'URL',
+            'URL2'
+        ]
+    }],
+    'agencyName': {'value': 'test'},
+    'docketId': {'value': 'docket-number-5'},
+    'documentId': {'value': 'document-number-10'}
+}
+
+
+@pytest.fixture(name='one_attachment_many_file_document')
+def fixture_one_attachment_many_files_document():
+    response = document_packager.package_document(ATTACHMENT_MANY_FILES_JSON,
+                                                  CLIENT_ID, JOB_ID)
+    return response
+
+
+MANY_ATTACHMENTS_JSON = {
+    "attachments": [{
+        "attachmentOrderNumber": 1,
+        'fileFormats': [
+            'URL'
+        ]
+    }, {
+        "attachmentOrderNumber": 2,
+        'fileFormats': [
+            'URL2',
+        ]
+    }],
+    'agencyName': {'value': 'test'},
+    'docketId': {'value': 'docket-number-5'},
+    'documentId': {'value': 'document-number-10'}
+}
+
+
+@pytest.fixture(name='many_attachments_document')
+def fixture_many_attachments_document():
+    response = document_packager.package_document(ATTACHMENT_MANY_FILES_JSON,
+                                                  CLIENT_ID, JOB_ID)
+    return response
+
+
+def test_client_id(document):
+    assert document['client_id'] == CLIENT_ID
+
+
+def test_job_id(document):
+    assert document['job_id'] == JOB_ID
+
+
+def test_folder_name(document):
+    assert document['data']['folder_name'] == \
+           'test/docket-number-5/document-number-10/'
+
+
+def test_file_name(document):
+    assert document['data']['file_name'] == \
+           'basic_document.json'
+
+
+def test_document_data(document):
+    assert document['data']['data'] == TEST_JSON
+
+
+def test_one_job(one_downloads_document):
+    assert one_downloads_document['jobs']['fileFormats'][0] == 'URL'
+
+
+def test_multiple_fileformats(many_downloads_document):
+    assert many_downloads_document['jobs']['fileFormats'][0] == 'URL'
+    assert many_downloads_document['jobs']['fileFormats'][1] == 'URL2'
+
+
+def test_one_attachment(one_attachment_document):
+    assert one_attachment_document['jobs']['fileFormats'][0] == 'URL'
+
+
+def test_one_attachment_many_fileformats(one_attachment_many_file_document):
+    assert one_attachment_many_file_document['jobs']['fileFormats'][0] == 'URL'
+    assert one_attachment_many_file_document['jobs']['fileFormats'][1] == \
+        'URL2'
+
+
+def test_many_attachments(many_attachments_document):
+    assert many_attachments_document['jobs']['fileFormats'][0] == 'URL'
+    assert many_attachments_document['jobs']['fileFormats'][1] == 'URL2'

--- a/tests/c20_client/test_download.py
+++ b/tests/c20_client/test_download.py
@@ -12,7 +12,7 @@ def test_mock_response():
     with requests_mock.Mocker() as mock:
         mock.get(URL, json='document received')
         response = document_download.download_document(API_KEY, DOC_ID)
-        assert response[0] == 'document received'
+        assert response == 'document received'
 
 
 def test_incorrect_id_pattern():
@@ -47,34 +47,3 @@ def test_exceed_call_limit():
                  status_code=429)
         with pytest.raises(reggov_api_doc_error.ExceedCallLimitException):
             document_download.download_document(API_KEY, DOC_ID)
-
-
-def test_file_formats():
-    with requests_mock.Mocker() as mock:
-        mock.get(URL, json={'fileFormats': ['file link']})
-        response = document_download.download_document(API_KEY, DOC_ID)
-        assert response[1][0] == 'file link'
-
-
-def test_multiple_file_formats():
-    with requests_mock.Mocker() as mock:
-        mock.get(URL, json={'fileFormats': ['file link', 'file link2']})
-        response = document_download.download_document(API_KEY, DOC_ID)
-        assert response[1][0] == 'file link'
-        assert response[1][1] == 'file link2'
-
-
-def test_attachments():
-    with requests_mock.Mocker() as mock:
-        mock.get(URL, json={'attachments': [{'fileFormats': ['file link']}]})
-        response = document_download.download_document(API_KEY, DOC_ID)
-        assert response[1][0] == 'file link'
-
-
-def test_multiple_attachments():
-    with requests_mock.Mocker() as mock:
-        mock.get(URL, json={'attachments': [{'fileFormats': ['file link']},
-                                            {'fileFormats': ['file link2']}]})
-        response = document_download.download_document(API_KEY, DOC_ID)
-        assert response[1][0] == 'file link'
-        assert response[1][1] == 'file link2'


### PR DESCRIPTION
* make the packager take in a document and return the client id, job id, json data, and jobs
* make the packager find the download jobs in a given document by searching for file formats
	and attachments
* removed functionality from the document_download to find download jobs